### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/edaviles0842/40a427f8-5d7a-4403-b52c-7f283740ae13/79e10d3a-12d4-4a1c-a62e-7a7976172697/_apis/work/boardbadge/4d6b4235-a040-4e1b-92e9-71f534029470)](https://dev.azure.com/edaviles0842/40a427f8-5d7a-4403-b52c-7f283740ae13/_boards/board/t/79e10d3a-12d4-4a1c-a62e-7a7976172697/Microsoft.RequirementCategory)
 # demolab1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4322](https://dev.azure.com/edaviles0842/40a427f8-5d7a-4403-b52c-7f283740ae13/_workitems/edit/4322). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.